### PR TITLE
Update DB initialization, job tracking, and uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AI-based Asynchronous Data Processor example using Flask and SQLite.
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-flask --app app.py initdb  # create sample users
+flask --app app.py initdb  # create demo users
 ```
 
 ## Running
@@ -17,4 +17,4 @@ flask --app app.py initdb  # create sample users
 FLASK_APP=app.py flask run
 ```
 
-Access the application at `http://localhost:5000/?token=analyst-token` for the analyst user or `http://localhost:5000/?token=super-token` for the supervisor.
+Access the application at `http://localhost:5000/?token=demo` for the analyst user or `http://localhost:5000/?token=maxiasuper` for the supervisor.

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
 <h2>Your jobs</h2>
 <ul>
   {% for job in jobs %}
-    <li>Job {{ job.id }} - {{ job.status }} - estimate: {{ job.token_estimate }} tokens - used: {{ job.tokens_used }} tokens
+    <li>Job {{ job.id }} - {{ job.status }} - estimate: {{ job.token_estimate }} tokens - used: {{ job.tokens_used }} tokens{% if job.error %} - error: {{ job.error }}{% endif %}
       {% if user.role == 'supervisor' and job.status == 'pending' %}
         <form action="/jobs/{{job.id}}/approve" method="post" style="display:inline;">
           <input type="hidden" name="token" value="{{ token }}"/>


### PR DESCRIPTION
## Summary
- extend `Job` model with config JSON and error tracking
- save uploads under per-job folders and keep config parameters in DB
- include error information in job status and UI
- initialize database with demo users
- update README with new tokens

## Testing
- `python -m compileall -q .`
- started Flask app to ensure it runs

------
https://chatgpt.com/codex/tasks/task_e_6848496a4278832f89e651ac0f0d3bb7