### PR TITLE
Add downloadable output CSV

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,18 @@
   "retry_times": 3,
   "max_rows": 10,
   "model": "placeholder",
-  "target": "text",
-  "new_columns": ["length"]
+  "target": "sample_text",
+  "new_columns": ["subject", "predicate", "verb"],
+  "verbs": [
+    "corre",
+    "iremos",
+    "has visto",
+    "estudia",
+    "terminó",
+    "está",
+    "llega",
+    "cancelaremos",
+    "bailaron",
+    "entiendo"
+  ]
 }

--- a/data.csv
+++ b/data.csv
@@ -1,3 +1,11 @@
-id,text
-1,Hello world
-2,Another sample row
+id,sample_text
+1,El perro corre felizmente por el parque.
+2,Mañana iremos al cine con nuestros amigos.
+3,¿Has visto mis llaves por algún lado?
+4,María estudia medicina en la universidad.
+5,Aunque estaba cansado, terminó todo su trabajo.
+6,¡Qué hermosa está la luna esta noche!
+7,El tren llega a las ocho en punto.
+8,Si llueve, cancelaremos el picnic.
+9,Carlos y Ana bailaron toda la noche.
+10,No entiendo por qué no me llamaste ayer.

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
     <th>Estimate</th>
     <th>Used</th>
     <th>Error</th>
+    <th>Output</th>
     {% if user.role == 'supervisor' %}<th>Actions</th>{% endif %}
   </tr>
   {% for job in jobs %}
@@ -43,6 +44,11 @@
     <td>{{ job.token_estimate }}</td>
     <td>{{ job.tokens_used }}</td>
     <td>{{ job.error or '' }}</td>
+    <td>
+      {% if job.status == 'done' and job.output_path %}
+        <a href="/jobs/{{job.id}}/output?token={{ token }}">Download</a>
+      {% else %}-{% endif %}
+    </td>
     {% if user.role == 'supervisor' %}
     <td>
       {% if job.status == 'pending' %}


### PR DESCRIPTION
## Summary
- extend Job model with `output_path`
- add route and link to download processed CSV results
- implement rudimentary subject/verb extraction logic
- write processed rows to `output.csv`
- update config and sample data

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6849ab1e8358832fabeaf4c38e0ba381