### PR TITLE
Update config and directive handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Access the application at `http://localhost:5000/?token=demo` for the analyst us
 The supervisor dashboard lists the history of all jobs with controls to approve,
 reject or cancel them.
 
-The configuration file must include the OpenAI API key, model parameters, the CSV delimiter and how often to create snapshots. The app uses OpenAI's JSON mode to enforce structured responses, so make sure you have a recent `openai` package installed. See `config.json` for an example of the expected format.
+The configuration file must include the OpenAI API key **encoded in base64**, model parameters, the CSV delimiter and how often to create snapshots.  The prompt for the AI is provided separately in `directive.txt`.  The app uses OpenAI's JSON mode to enforce structured responses, so make sure you have a recent `openai` package installed.  See `config.json` and `directive.txt` for examples of the expected format.
 
 Jobs can optionally include a short description so they are easier to recognize in the dashboard.
+When creating a job you must upload three files: the CSV data, the `config.json` settings file and the `directive.txt` file containing the prompt for the AI.

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import threading
 import time
 import shutil
 import random
+import base64
 import openai
 from datetime import datetime
 from flask import Flask, request, jsonify, render_template, redirect, url_for, send_file
@@ -33,6 +34,7 @@ class Job(db.Model):
     user = db.relationship('User', backref='jobs')
     csv_path = db.Column(db.String(200), nullable=False)
     config_path = db.Column(db.String(200), nullable=False)
+    directive_path = db.Column(db.String(200), nullable=False)
     config_json = db.Column(db.Text, nullable=False)
     # possible states: pending, approved, processing, done, failed,
     # rejected, cancelled
@@ -75,7 +77,7 @@ def analyze_csv(csv_path: str, target: str, delimiter: str = ','):
                 return True, text  # return first non-empty row text
     return False, None
 
-def token_estimator(csv_path: str, config: dict, sample_size: int = 5) -> int:
+def token_estimator(csv_path: str, config: dict, directive: str, sample_size: int = 5) -> int:
     """Estimate total token usage by sampling rows and querying OpenAI."""
     delimiter = config.get('delimiter', ',')
     with open(csv_path, newline='', encoding='utf-8') as f:
@@ -85,7 +87,8 @@ def token_estimator(csv_path: str, config: dict, sample_size: int = 5) -> int:
         return 0
 
     sample_rows = random.sample(rows, min(sample_size, len(rows)))
-    client = openai.OpenAI(api_key=config.get('openai_api_key'))
+    api_key = base64.b64decode(config.get('openai_api_key')).decode()
+    client = openai.OpenAI(api_key=api_key)
     total_tokens = 0
     successful = 0
 
@@ -100,7 +103,7 @@ def token_estimator(csv_path: str, config: dict, sample_size: int = 5) -> int:
                 resp = client.chat.completions.create(
                     model=config.get('model', 'gpt-3.5-turbo'),
                     messages=[
-                        {"role": "system", "content": config.get('directive', '')},
+                        {"role": "system", "content": directive},
                         {"role": "user", "content": text}
                     ],
                     temperature=config.get('temperature', 0.2),
@@ -122,18 +125,19 @@ def token_estimator(csv_path: str, config: dict, sample_size: int = 5) -> int:
     avg_tokens = total_tokens / successful
     return int(avg_tokens * len(rows))
 
-def openai_process(row: dict, config: dict) -> tuple:
+def openai_process(row: dict, config: dict, directive: str) -> tuple:
     """Process a row with OpenAI and return the updated row and tokens used."""
     text = row.get(config['target'], '') or ''
     retries = config.get('retry_times', 3)
-    client = openai.OpenAI(api_key=config.get('openai_api_key'))
+    api_key = base64.b64decode(config.get('openai_api_key')).decode()
+    client = openai.OpenAI(api_key=api_key)
     last_err = None
     for _ in range(retries):
         try:
             resp = client.chat.completions.create(
                 model=config.get('model', 'gpt-3.5-turbo'),
                 messages=[
-                    {"role": "system", "content": config.get('directive', '')},
+                    {"role": "system", "content": directive},
                     {"role": "user", "content": text}
                 ],
                 temperature=config.get('temperature', 0.2),
@@ -160,6 +164,8 @@ def process_job_async(job_id: int):
         db.session.commit()
 
         config = json.loads(job.config_json)
+        with open(job.directive_path, 'r', encoding='utf-8') as df:
+            directive_text = df.read()
         delimiter = config.get('delimiter', ',')
         snapshot_interval = config.get('snapshot_rows', 100)
 
@@ -189,7 +195,7 @@ def process_job_async(job_id: int):
                         continue
 
                     try:
-                        result, used = openai_process(row, config)
+                        result, used = openai_process(row, config, directive_text)
                     except Exception:
                         job.error_rows += 1
                         result, used = row, 0
@@ -242,7 +248,9 @@ def verify_files():
         return jsonify({'error': 'Unauthorized'}), 401
     csv_file = request.files.get('csv')
     config_file = request.files.get('config')
-    if not csv_file or not config_file:
+    directive_file = request.files.get('directive')
+    directive_file = request.files.get('directive')
+    if not csv_file or not config_file or not directive_file:
         return jsonify({'error': 'Missing files'}), 400
 
     csv_path = os.path.join(app.config['UPLOAD_FOLDER'], f'tmp_{csv_file.filename}')
@@ -256,6 +264,8 @@ def verify_files():
         except json.JSONDecodeError:
             return jsonify({'error': 'Invalid config JSON'}), 400
 
+    directive_text = directive_file.read().decode('utf-8')
+
     if not validate_config(config):
         return jsonify({'error': 'Config missing required fields'}), 400
 
@@ -264,7 +274,7 @@ def verify_files():
         return jsonify({'error': 'CSV missing target column or no valid rows'}), 400
 
     try:
-        token_est = token_estimator(csv_path, config)
+        token_est = token_estimator(csv_path, config, directive_text)
     except Exception as e:
         return jsonify({'error': str(e)}), 400
     return jsonify({'message': 'verified', 'token_estimate': token_est})
@@ -281,7 +291,7 @@ def create_job():
     token_estimate = request.form.get('token_estimate')
     description = request.form.get('description')
 
-    if not all([csv_file, config_file, token_estimate]):
+    if not all([csv_file, config_file, directive_file, token_estimate]):
         return 'Missing data', 400
 
     # read config file to store json parameters
@@ -293,7 +303,8 @@ def create_job():
         return 'Invalid config', 400
 
     job = Job(user_id=user.id, token_estimate=int(token_estimate),
-              csv_path='', config_path='', config_json=json.dumps(config_data),
+              csv_path='', config_path='', directive_path='',
+              config_json=json.dumps(config_data),
               description=description)
     db.session.add(job)
     db.session.commit()
@@ -302,12 +313,15 @@ def create_job():
     os.makedirs(job_folder, exist_ok=True)
     csv_path = os.path.join(job_folder, csv_file.filename)
     config_path = os.path.join(job_folder, 'config.json')
+    directive_path = os.path.join(job_folder, 'directive.txt')
     csv_file.save(csv_path)
     with open(config_path, 'w', encoding='utf-8') as f:
         f.write(config_bytes.decode('utf-8'))
+    directive_file.save(directive_path)
 
     job.csv_path = csv_path
     job.config_path = config_path
+    job.directive_path = directive_path
     db.session.commit()
 
     return redirect(url_for('index', token=token))

--- a/config.json
+++ b/config.json
@@ -1,13 +1,12 @@
 {
   "retry_times": 3,
   "max_rows": 10,
-  "openai_api_key": "sk-replace-me",
+  "openai_api_key": "c2stcmVwbGFjZS1tZQ==",
   "model": "gpt-3.5-turbo",
   "target": "sample_text",
   "delimiter": ",",
   "snapshot_rows": 5,
   "new_columns": ["subject", "predicate", "verb"],
-  "directive": "Extract the subject, predicate and verb from the input text using Spanish grammar rules. Respond using JSON with keys subject, predicate and verb only.",
   "schema": {
     "type": "object",
     "properties": {

--- a/directive.txt
+++ b/directive.txt
@@ -1,0 +1,1 @@
+Extract the subject, predicate and verb from the input text using Spanish grammar rules. Respond using JSON with keys subject, predicate and verb only.

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,8 @@
     function enableVerify() {
       const csv = document.getElementById('csv').files.length;
       const config = document.getElementById('config').files.length;
-      document.getElementById('verify').disabled = !(csv && config);
+      const directive = document.getElementById('directive').files.length;
+      document.getElementById('verify').disabled = !(csv && config && directive);
     }
     function verifyFiles() {
       const formData = new FormData(document.getElementById('jobForm'));
@@ -102,6 +103,7 @@
   Description: <input type="text" name="description"><br>
   CSV: <input type="file" id="csv" name="csv" onchange="enableVerify()"><br>
   Config: <input type="file" id="config" name="config" onchange="enableVerify()"><br>
+  Directive: <input type="file" id="directive" name="directive" onchange="enableVerify()"><br>
   Token estimate: <span id="tokens">-</span><br>
   <button type="button" id="verify" onclick="verifyFiles()" disabled>Verify</button>
   <button type="submit" id="send" disabled>Send</button>


### PR DESCRIPTION
## Summary
- expect OpenAI API key in base64
- move directive text to separate `directive.txt` file
- require uploading the directive file when creating a job
- adjust HTML form and verification logic for the extra file

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f85185f8832fb1070da0421a51e2