### PR TITLE
Handle missing json hint automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The supervisor dashboard lists the history of all jobs with controls to approve,
 reject or cancel them.
 
 The configuration file must include the OpenAI API key **encoded in base64**, model parameters, the CSV delimiter and how often to create snapshots.  The prompt for the AI is provided separately in `directive.txt`.  The app uses OpenAI's JSON mode to enforce structured responses, so make sure you have a recent `openai` package installed.  See `config.json` and `directive.txt` for examples of the expected format.
+When using JSON mode your prompt must mention the word "json" somewhere.  The application now appends a short reminder automatically if it is missing.
 
 Jobs can optionally include a short description so they are easier to recognize in the dashboard.
 When creating a job you must upload three files: the CSV data, the `config.json` settings file and the `directive.txt` file containing the prompt for the AI.


### PR DESCRIPTION
## Summary
- ensure the directive includes the word `json` for OpenAI JSON mode
- mention this requirement in the README

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684adb02d9fc832fb49e49de2b889fdd