### PR TITLE
Add Docker support for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.db
+uploads/
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Ensure data directories exist
+RUN mkdir -p /data/uploads
+
+ENV FLASK_APP=app.py \
+    DB_PATH=/data/iadroc.db \
+    UPLOAD_FOLDER=/data/uploads
+
+EXPOSE 5000
+
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,24 @@ When using JSON mode your prompt must mention the word "json" somewhere.  The ap
 
 Jobs can optionally include a short description so they are easier to recognize in the dashboard.
 When creating a job you must upload three files: the CSV data, the `config.json` settings file and the `directive.txt` file containing the prompt for the AI.
+
+## Docker
+
+Build the Docker image and push it to Docker Hub (replace `youruser` with your username):
+
+```bash
+docker build -t youruser/iadroc:latest .
+docker push youruser/iadroc:latest
+```
+
+Run the container mounting a directory to persist the database and uploads:
+
+```bash
+docker run -d -p 5000:5000 \
+  -v $PWD/data:/data \
+  -e DB_PATH=/data/iadroc.db \
+  -e UPLOAD_FOLDER=/data/uploads \
+  --name iadroc youruser/iadroc:latest
+```
+
+Then open `http://localhost:5000/?token=demo` or `?token=maxiasuper` in your browser.

--- a/app.py
+++ b/app.py
@@ -12,9 +12,11 @@ from flask import Flask, request, jsonify, render_template, redirect, url_for, s
 from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///iadroc.db'
+DB_PATH = os.getenv('DB_PATH', 'iadroc.db')
+UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', 'uploads')
+app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DB_PATH}'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['UPLOAD_FOLDER'] = 'uploads'
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 db = SQLAlchemy(app)
@@ -498,8 +500,8 @@ def job_snapshot(job_id):
 
 @app.cli.command('initdb')
 def initdb():
-    if os.path.exists('iadroc.db'):
-        os.remove('iadroc.db')
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
     shutil.rmtree(app.config['UPLOAD_FOLDER'], ignore_errors=True)
     os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
     db.create_all()


### PR DESCRIPTION
## Summary
- set database path and upload folder via environment variables
- add Dockerfile using gunicorn for production
- ignore build artifacts with .dockerignore
- document how to build, push and run the container

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684adec92ab8832f90ca215057ae34a0