### PR TITLE
Fix missing gunicorn in Docker image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 Flask-SQLAlchemy
 openai
 click
+gunicorn


### PR DESCRIPTION
## Summary
- add gunicorn to requirements so the Docker container can start correctly

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae78d2320832f9e897335bcf63bb8